### PR TITLE
Add player search across rounds with case-insensitive matching.

### DIFF
--- a/public/pgn/manifest.json
+++ b/public/pgn/manifest.json
@@ -1,0 +1,4 @@
+{
+  "tournamentName": "Local demo",
+  "rounds": [{ "id": "1", "label": "Round 1", "file": "round_1.pgn" }]
+}

--- a/public/pgn/round_1.pgn
+++ b/public/pgn/round_1.pgn
@@ -1,0 +1,9 @@
+[Event "Local demo"]
+[Site "?"]
+[Date "2024.01.01"]
+[Round "1"]
+[White "Alice Example"]
+[Black "Bob Sample"]
+[Result "1-0"]
+
+1. e4 e5 2. Qh5 Nc6 3. Bc4 Nf6 4. Qxf7#

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Layout } from "./components/Layout";
 import { HomePage } from "./components/HomePage";
 import { RoundGamesPage } from "./components/RoundGamesPage";
 import { GameDetailPage } from "./components/GameDetailPage";
+import { PlayerSearchPage } from "./components/PlayerSearchPage";
 
 export default function App() {
   const configuredPgnBase = import.meta.env.VITE_PGN_BASE_URL;
@@ -34,6 +35,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<HomePage repository={repository} />} />
+          <Route path="search" element={<PlayerSearchPage repository={repository} />} />
           <Route path="round/:roundId" element={<RoundGamesPage repository={repository} />} />
           <Route path="round/:roundId/game/:gameIndex" element={<GameDetailPage repository={repository} />} />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/GameDetailPage.tsx
+++ b/src/components/GameDetailPage.tsx
@@ -19,29 +19,27 @@ export function GameDetailPage({ repository }: Props) {
 
   useEffect(() => {
     let cancelled = false;
-    setError(null);
-    setGame(null);
-    setReady(false);
-    if (Number.isNaN(index) || index < 0) {
-      setError("Invalid game index.");
-      setReady(true);
-      return;
-    }
 
-    repository
-      .loadManifest()
-      .then((m) => {
+    const run = async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      setError(null);
+      setGame(null);
+      setReady(false);
+      try {
+        if (Number.isNaN(index) || index < 0) {
+          setError("Invalid game index.");
+          return;
+        }
+        const m = await repository.loadManifest();
         if (cancelled) return;
         const entry = m.rounds.find((r) => r.id === roundId);
         if (!entry) {
           setError(`Unknown round id: ${roundId ?? ""}`);
           return;
         }
-        return repository.loadRoundPgnFile(entry.file);
-      })
-      .then((text) => {
+        const text = await repository.loadRoundPgnFile(entry.file);
         if (cancelled) return;
-        if (text === undefined) return;
         const games = parsePgnFile(text);
         const g = games[index];
         if (!g) {
@@ -49,13 +47,14 @@ export function GameDetailPage({ repository }: Props) {
           return;
         }
         setGame(g);
-      })
-      .catch((e: unknown) => {
+      } catch (e: unknown) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load game");
-      })
-      .finally(() => {
+      } finally {
         if (!cancelled) setReady(true);
-      });
+      }
+    };
+
+    void run();
 
     return () => {
       cancelled = true;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -27,6 +27,14 @@ export function Layout() {
             ) : null}
             <span>{branding.siteTitle}</span>
           </Link>
+          <nav className="app-nav" aria-label="Main">
+            <Link to="/" style={{ color: branding.headerText }}>
+              Home
+            </Link>
+            <Link to="/search" style={{ color: branding.headerText }}>
+              Player search
+            </Link>
+          </nav>
         </div>
       </header>
       <main className="app-main">

--- a/src/components/PlayerSearchPage.tsx
+++ b/src/components/PlayerSearchPage.tsx
@@ -1,0 +1,160 @@
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { parsePgnFile } from "../adapters/pgnParser";
+import type { PgnManifest, ParsedGame } from "../domain/types";
+import type { PgnRepository } from "../adapters/pgnRepository";
+import {
+  buildPlayerSearchRows,
+  filterPlayerSearchRows,
+  normalizePlayerSearchQuery,
+  type PlayerSearchRow,
+} from "../lib/playerSearch";
+
+const RESULTS_CHUNK = 150;
+
+type Props = {
+  repository: PgnRepository;
+};
+
+function PlayerSearchMatchList({ matches }: { matches: PlayerSearchRow[] }) {
+  const [visibleCount, setVisibleCount] = useState(RESULTS_CHUNK);
+  const visibleMatches = matches.slice(0, visibleCount);
+  return (
+    <div className="search-results-wrap">
+      <ul className="game-list search-results-list">
+        {visibleMatches.map((row) => (
+          <li key={`${row.roundId}-${row.gameIndex}`}>
+            <Link to={`/round/${row.roundId}/game/${row.gameIndex}`}>
+              <strong>
+                {row.white} — {row.black}
+              </strong>
+              <span className="result-badge">{row.result}</span>
+              <span className="muted small search-result-round"> · {row.roundLabel}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      {visibleCount < matches.length ? (
+        <button
+          type="button"
+          className="search-load-more"
+          onClick={() => setVisibleCount((c) => c + RESULTS_CHUNK)}
+        >
+          Show more ({matches.length - visibleCount} remaining)
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export function PlayerSearchPage({ repository }: Props) {
+  const [manifest, setManifest] = useState<PgnManifest | null>(null);
+  const [gamesByRound, setGamesByRound] = useState<ParsedGame[][] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+  const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query);
+  const normalizedQuery = useMemo(
+    () => normalizePlayerSearchQuery(deferredQuery),
+    [deferredQuery],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const run = async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      setError(null);
+      setManifest(null);
+      setGamesByRound(null);
+      setReady(false);
+      try {
+        const m = await repository.loadManifest();
+        if (cancelled) return;
+        setManifest(m);
+        const texts = await Promise.all(m.rounds.map((r) => repository.loadRoundPgnFile(r.file)));
+        if (cancelled) return;
+        setGamesByRound(texts.map((t) => parsePgnFile(t)));
+      } catch (e: unknown) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load games");
+      } finally {
+        if (!cancelled) setReady(true);
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [repository]);
+
+  const indexRows = useMemo(() => {
+    if (!manifest || !gamesByRound) return [];
+    return buildPlayerSearchRows(manifest.rounds, gamesByRound);
+  }, [manifest, gamesByRound]);
+
+  const matches = useMemo(
+    () => filterPlayerSearchRows(indexRows, normalizedQuery),
+    [indexRows, normalizedQuery],
+  );
+
+  const pending = query !== deferredQuery;
+
+  if (!ready) {
+    return <p className="muted">Loading games for search…</p>;
+  }
+
+  if (error) {
+    return (
+      <div className="panel error-panel">
+        <p>{error}</p>
+        <Link to="/">← Home</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p>
+        <Link to="/">← Home</Link>
+      </p>
+      <h1>Player search</h1>
+      {manifest ? <p className="muted">{manifest.tournamentName}</p> : null}
+
+      <form className="player-search-form" role="search" onSubmit={(e) => e.preventDefault()}>
+        <label htmlFor="player-search-input" className="player-search-label">
+          Find games by player name
+        </label>
+        <input
+          id="player-search-input"
+          className="player-search-input"
+          type="search"
+          name="q"
+          autoComplete="off"
+          spellCheck={false}
+          enterKeyHint="search"
+          placeholder="e.g. Carlsen"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-busy={pending}
+        />
+      </form>
+
+      <p className="muted small player-search-status" aria-live="polite">
+        {normalizedQuery.length === 0
+          ? `${indexRows.length} games indexed. Type a name to search.`
+          : pending
+            ? "Searching…"
+            : matches.length === 0
+              ? "No games match that name."
+              : `${matches.length} game${matches.length === 1 ? "" : "s"} found`}
+      </p>
+
+      {normalizedQuery.length > 0 && matches.length > 0 ? (
+        <PlayerSearchMatchList key={normalizedQuery} matches={matches} />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/RoundGamesPage.tsx
+++ b/src/components/RoundGamesPage.tsx
@@ -22,14 +22,16 @@ export function RoundGamesPage({ repository }: Props) {
 
   useEffect(() => {
     let cancelled = false;
-    setError(null);
-    setGames([]);
-    setReady(false);
-    setManifest(null);
 
-    repository
-      .loadManifest()
-      .then((m) => {
+    const run = async () => {
+      await Promise.resolve();
+      if (cancelled) return;
+      setError(null);
+      setGames([]);
+      setReady(false);
+      setManifest(null);
+      try {
+        const m = await repository.loadManifest();
         if (cancelled) return;
         setManifest(m);
         const entry = m.rounds.find((r) => r.id === roundId);
@@ -37,19 +39,17 @@ export function RoundGamesPage({ repository }: Props) {
           setError(`Unknown round id: ${roundId ?? ""}`);
           return;
         }
-        return repository.loadRoundPgnFile(entry.file);
-      })
-      .then((text) => {
+        const text = await repository.loadRoundPgnFile(entry.file);
         if (cancelled) return;
-        if (text === undefined) return;
         setGames(parsePgnFile(text));
-      })
-      .catch((e: unknown) => {
+      } catch (e: unknown) {
         if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load round");
-      })
-      .finally(() => {
+      } finally {
         if (!cancelled) setReady(true);
-      });
+      }
+    };
+
+    void run();
 
     return () => {
       cancelled = true;

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,24 @@ a:hover {
 .app-header-inner {
   max-width: 960px;
   margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+}
+
+.app-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.app-nav a:hover {
+  text-decoration: underline;
 }
 
 .app-title-link {
@@ -138,4 +156,65 @@ a:hover {
 .vs {
   font-weight: 400;
   color: #718096;
+}
+
+.player-search-form {
+  margin: 1.25rem 0 0.5rem;
+}
+
+.player-search-label {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.player-search-input {
+  width: 100%;
+  max-width: min(100%, 28rem);
+  min-height: 2.75rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5e0;
+  background: #fff;
+}
+
+.player-search-input:focus {
+  outline: 2px solid #2b6cb0;
+  outline-offset: 1px;
+}
+
+.player-search-status {
+  margin-top: 0.35rem;
+}
+
+.search-results-wrap {
+  margin-top: 1rem;
+}
+
+.search-results-list {
+  max-height: min(70vh, 36rem);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.search-result-round {
+  display: inline;
+}
+
+.search-load-more {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  min-height: 2.75rem;
+  border-radius: 6px;
+  border: 1px solid #cbd5e0;
+  background: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.search-load-more:hover {
+  background: #edf2f7;
 }

--- a/src/lib/playerSearch.test.ts
+++ b/src/lib/playerSearch.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildPlayerSearchRows, filterPlayerSearchRows, normalizePlayerSearchQuery } from "./playerSearch";
+import type { ParsedGame } from "../domain/types";
+
+function game(white: string, black: string): ParsedGame {
+  return {
+    white,
+    black,
+    result: "1-0",
+    rawPgn: "",
+  };
+}
+
+describe("playerSearch", () => {
+  it("normalizes queries with trim and case folding", () => {
+    expect(normalizePlayerSearchQuery("  Carlsen ")).toBe("carlsen");
+  });
+
+  it("matches white or black case-insensitively via substring", () => {
+    const rounds = [{ id: "1", label: "Round 1" }];
+    const gamesByRound: ParsedGame[][] = [[game("Magnus Carlsen", "Fabiano Caruana")]];
+    const rows = buildPlayerSearchRows(rounds, gamesByRound);
+    expect(filterPlayerSearchRows(rows, "carlsen")).toHaveLength(1);
+    expect(filterPlayerSearchRows(rows, "CARUANA")).toHaveLength(1);
+    expect(filterPlayerSearchRows(rows, "nope")).toHaveLength(0);
+  });
+
+  it("returns no matches for empty normalized query", () => {
+    const rounds = [{ id: "1", label: "Round 1" }];
+    const rows = buildPlayerSearchRows(rounds, [[game("A", "B")]]);
+    expect(filterPlayerSearchRows(rows, "")).toHaveLength(0);
+  });
+});

--- a/src/lib/playerSearch.ts
+++ b/src/lib/playerSearch.ts
@@ -1,0 +1,49 @@
+import type { ParsedGame } from "../domain/types";
+
+export function normalizePlayerSearchQuery(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+export type PlayerSearchRow = {
+  roundId: string;
+  roundLabel: string;
+  gameIndex: number;
+  white: string;
+  black: string;
+  result: string;
+  whiteNorm: string;
+  blackNorm: string;
+};
+
+export function buildPlayerSearchRows(
+  rounds: { id: string; label: string }[],
+  gamesByRound: ParsedGame[][],
+): PlayerSearchRow[] {
+  const rows: PlayerSearchRow[] = [];
+  for (let r = 0; r < rounds.length; r++) {
+    const round = rounds[r]!;
+    const games = gamesByRound[r] ?? [];
+    for (let i = 0; i < games.length; i++) {
+      const g = games[i]!;
+      rows.push({
+        roundId: round.id,
+        roundLabel: round.label,
+        gameIndex: i,
+        white: g.white,
+        black: g.black,
+        result: g.result,
+        whiteNorm: g.white.toLowerCase(),
+        blackNorm: g.black.toLowerCase(),
+      });
+    }
+  }
+  return rows;
+}
+
+export function filterPlayerSearchRows(rows: PlayerSearchRow[], query: string): PlayerSearchRow[] {
+  const normalizedQuery = normalizePlayerSearchQuery(query);
+  if (normalizedQuery.length === 0) return [];
+  return rows.filter(
+    (row) => row.whiteNorm.includes(normalizedQuery) || row.blackNorm.includes(normalizedQuery),
+  );
+}


### PR DESCRIPTION
Reintroduce /search page: parallel round loads, pre-lowercased index rows, useDeferredValue for typing, chunked results with show more and scrollable list. Header nav links Home and Player search. Align fetch effects with hooks lint via deferred microtask reset. Include local demo PGN under public/pgn for dev without GitHub data.

**First Review:**
1. Let’s add a player search box so I can type a name and see every game where they’re White or Black—can you wire that up to how we already load and list games?

2. Let’s do a simple player filter on the games list: substring match on the PGN headers, case-insensitive, with a clear empty state when nothing matches.

**Second Review:**
3. Now lets add search-by-player with results that link straight into the existing game view, and a couple of tests for the matching logic so we don’t break it later.